### PR TITLE
fixed issues with categorical data

### DIFF
--- a/src/CART.jl
+++ b/src/CART.jl
@@ -24,17 +24,18 @@ function split(N::Node)
         # for categorical features, we calculate the gini impurity for each split (e.g. feature == class1, feature == class2, ...)
         if is_categorical
             # TODO: Test & Debug Categorical case
-            # TODO: collect from data not N.dataset or write another collect_classes that takes a node_data index list as well
-            classes = collect_classes(N.dataset, i)
-            for class in classes
+            classes = collect_classes(N.dataset, N.node_data, i)
+            if size(classes)[1] >= 2
+                for class in classes
 
-                decision = Decision(equal, i, class)
-                impurity = gini_impurity(N.dataset, N.labels, N.node_data, decision.fn, decision.param, decision.feature)
+                    decision = Decision(equal, i, class)
+                    impurity = gini_impurity(N.dataset, N.labels, N.node_data, decision.fn, decision.param, decision.feature)
 
-                if best_feature == -1 || (impurity < best_impurity)
-                    best_feature = i
-                    best_impurity = impurity
-                    best_decision = decision
+                    if best_feature == -1 || (impurity < best_impurity)
+                        best_feature = i
+                        best_impurity = impurity
+                        best_decision = decision
+                    end
                 end
             end
         # for numerical features, we sort them and calculate the gini impurity for each split (splitting at the mean between each two list neighbors)

--- a/src/CARTutils.jl
+++ b/src/CARTutils.jl
@@ -9,13 +9,13 @@ Split the dataset indices contained in node_data into two sets via the decision 
 
 # Arguments
 
-- `dataset::Matrix{Union{Real, String}}`: the dataset to split on (the datapoints are assumed to be contained rowwise)
+- `dataset::AbstractMatrix`: the dataset to split on (the datapoints are assumed to be contained rowwise)
 - `node_data::Vector{Int64}`: the index list, indexing dataset, to be split
 - `decision_fn::Function`: the decision function taking as input a datapoint, decision_param and decision_feature and returning a Bool
 - `decision_param::Union{Real, String}`: a parameter to the decision function. This can be a class name or a numeric threshold.
 - `decision_feature::Int64`: the index of the dimension of datapoints along which to split
 """
-function split_indices(dataset::Matrix{S}, node_data::Vector{Int64}, decision_fn::Function, decision_param::T, decision_feature::Int64) where {S<:Union{Real, String}, T<:Union{Real, String}}
+function split_indices(dataset::AbstractMatrix, node_data::Vector{Int64}, decision_fn::Function, decision_param::T, decision_feature::Int64) where {T<:Union{Real, String}}
     true_child_data::Vector{Int64} = []
     false_child_data::Vector{Int64} = []
     for datapoint_idx in node_data
@@ -35,11 +35,11 @@ Split the dataset indices contained in node_data into two sets via the decision 
 
 # Arguments
 
-- `dataset::Matrix{Union{Real, String}}`: the dataset to split on (the datapoints are assumed to be contained rowwise)
+- `dataset::AbstractMatrix`: the dataset to split on (the datapoints are assumed to be contained rowwise)
 - `node_data::Vector{Int64}`: the index list, indexing the dataset, to be split
 - `decision_fn::Function`: the decision function taking as input a datapoint and returning a Bool
 """
-function split_indices(dataset::Matrix{S}, node_data::Vector{Int64}, decision_fn::Function) where S<:Union{Real, String}
+function split_indices(dataset::AbstractMatrix, node_data::Vector{Int64}, decision_fn::Function)
     true_child_data::Vector{Int64} = []
     false_child_data::Vector{Int64} = []
     for datapoint_idx in node_data
@@ -90,15 +90,40 @@ Collect all unique classes among the specified column of the dataset.
 
 # Arguments
 
-- `dataset::Matrix{Union{Real, String}}`: the dataset to collect classes on
+- `dataset::AbstractMatrix`: the dataset to collect classes on
 - `column::Int64`: the index of the dataset column/feature to collect the classes on
 """
-function collect_classes(dataset::Matrix{S}, column::Int64) where S<:Union{Real, String}
+function collect_classes(dataset::AbstractMatrix, column::Int64)
     classes = Dict{String, Bool}()
     # TODO: check if passed column is out of bounds
     # TODO: check if passed column is categorical
     rows = size(dataset)[1]
     for i in range(1, rows)
+        value = dataset[i, column]
+        if !haskey(classes, value)
+            classes[value] = true
+        end
+    end
+    return collect(keys(classes))
+end
+
+"""
+    collect_classes(dataset, column)
+
+Collect all unique classes among a subset of the specified column of the dataset.
+
+# Arguments
+
+- `dataset::AbstractMatrix`: the dataset to collect classes on
+- `indices::Vector{Int64}`: the indices of the numeric labels to be considered
+- `column::Int64`: the index of the dataset column/feature to collect the classes on
+"""
+function collect_classes(dataset::AbstractMatrix, indices::Vector{Int64}, column::Int64)
+    classes = Dict{String, Bool}()
+    # TODO: check if passed column is out of bounds
+    # TODO: check if passed column is categorical
+    rows = size(dataset[indices])[1]
+    for i in indices
         value = dataset[i, column]
         if !haskey(classes, value)
             classes[value] = true

--- a/src/Node.jl
+++ b/src/Node.jl
@@ -7,10 +7,10 @@ A Node represents a decision in the Tree.
 It is a leaf with a prediction or has exactly one true and one false child and a decision
 function.
 """
-mutable struct Node{S<:Union{Real, String}, T<:Union{Number, String}}
+mutable struct Node{T<:Union{Number, String}}
     # Reference to whole dataset governed by the tree (This is not a copy as julia doesn't copy but only binds new aliases to the same object)
     # data points are rows, data features are columns
-    dataset::Union{Matrix{S}, Nothing}
+    dataset::Union{AbstractMatrix, Nothing}
     # labels can be categorical => String or numerical => Real
     labels::Union{Vector{T}, Nothing}
     # Indices of the data in the dataset being governed by this node
@@ -32,8 +32,8 @@ mutable struct Node{S<:Union{Real, String}, T<:Union{Number, String}}
 
     # Constructor handling assignments & splitting
     # TODO: replace classify::Bool with enum value for readability
-    function Node(dataset::Matrix{S}, labels::Vector{T}, node_data::Vector{Int64}, classify::Bool; depth=0, min_purity_gain=nothing, max_depth=0) where {S, T}
-        N = new{S, T}(dataset, labels, node_data)
+    function Node(dataset::AbstractMatrix, labels::Vector{T}, node_data::Vector{Int64}, classify::Bool; depth=0, min_purity_gain=nothing, max_depth=0) where {S, T}
+        N = new{T}(dataset, labels, node_data)
         N.depth = depth
         N.true_child = nothing
         N.false_child = nothing
@@ -59,6 +59,7 @@ mutable struct Node{S<:Union{Real, String}, T<:Union{Number, String}}
             N.true_child = Node(dataset, labels, true_data, classify, depth=N.depth+1, min_purity_gain=min_purity_gain, max_depth=max_depth)
             N.false_child = Node(dataset, labels, false_data, classify, depth=N.depth+1, min_purity_gain=min_purity_gain, max_depth=max_depth)
             # TODO: Do we want to set prediction to nothing in non-leaf nodes? It could be neat to just have it, if we already had to calculate it anyways.
+            # NOTE: The reason it is set to nothing here atm, is because N.prediction being nothing is later used to identify non-leaf nodes.
             N.prediction = nothing
         else
             # Clear decision as we don't want to split

--- a/src/Tree.jl
+++ b/src/Tree.jl
@@ -133,11 +133,11 @@ Train a decision tree on the given data using some algorithm (e.g. CART).
 # Arguments
 
 - `tree::AbstractDecisionTree`: the tree to be trained
-- `dataset::Matrix{Union{Real, String}}`: the training data
+- `dataset::AbstractMatrix`: the training data
 - `labels::Vector{Union{Real, String}}`: the target labels
 - `column_data::Bool`: whether the datapoints are contained in dataset columnwise
 """
-function fit!(tree::AbstractDecisionTree, features::Matrix{S}, labels::Vector{T}, column_data=false) where {S<:Union{Real, String}, T<:Union{Number, String}}
+function fit!(tree::AbstractDecisionTree, features::AbstractMatrix, labels::Vector{T}, column_data=false) where {T<:Union{Number, String}}
     _verify_fit!_args(tree, features, labels, column_data)
 
     classify = (tree isa DecisionTreeClassifier)
@@ -152,9 +152,9 @@ Traverses the tree for a given datapoint x and returns that trees prediction.
 # Arguments
 
 - `tree::AbstractDecisionTree`: the tree to predict with
-- `X::Union{Matrix{S}, Vector{S}`: the data to predict on
+- `X::Union{AbstractMatrix, AbstractVector`: the data to predict on
 """
-function predict(tree::AbstractDecisionTree, X::Union{Matrix{S}, Vector{S}}) where S<:Union{Real, String}
+function predict(tree::AbstractDecisionTree, X::Union{AbstractMatrix, AbstractVector})
     if tree.root === nothing
         error("Cannot predict from an empty tree.")
     end
@@ -162,7 +162,7 @@ function predict(tree::AbstractDecisionTree, X::Union{Matrix{S}, Vector{S}}) whe
     return predict(tree.root, X)
 end
 
-function predict(node::Node, datapoint::Vector{S}) where S<:Union{Real, String}
+function predict(node::Node, datapoint::AbstractVector)
     if is_leaf(node)
         return node.prediction
     end
@@ -174,7 +174,7 @@ function predict(node::Node, datapoint::Vector{S}) where S<:Union{Real, String}
     end
 end
 
-function predict(node::Node, dataset::Matrix{S}) where S<:Union{Real, String}
+function predict(node::Node, dataset::AbstractMatrix)
     if is_leaf(node)
         return node.prediction * ones(size(dataset, 1))
     end

--- a/test/cart_tests.jl
+++ b/test/cart_tests.jl
@@ -90,7 +90,14 @@ end
         8 9 2
         0 6 2
     ]
+    dataset_mixfs = [
+        7 "Old" 4 "Rich"
+        3 "Young" 4 "Poor"
+        3 "Young" 3 "Middle-class"
+        1 "Middle-aged" 7 "Middle-class"
+    ]
     abc_labels = ["A", "B", "C"]
+    abcd_labels = ["A", "B", "C", "D"]
     aabcbb_labels = ["A", "A", "B", "C", "B", "B"]
     @testset "Fit and Predict" begin
         t1 = DecisionTreeClassifier(max_depth=1)
@@ -138,31 +145,39 @@ end
         t_float = DecisionTreeClassifier(max_depth=3)
         t_string = DecisionTreeClassifier(max_depth=3)
         t_int = DecisionTreeClassifier(max_depth=3)
+        t_mixfs = DecisionTreeClassifier(max_depth=3)
 
         fit!(t_float, dataset_float, abc_labels)
         fit!(t_string, dataset_string,  abc_labels)
         fit!(t_int, dataset_int, aabcbb_labels)
+        fit!(t_mixfs, dataset_mixfs, abcd_labels)
 
         @test t_float.root isa Node
         @test t_string.root isa Node
-        @test t_int.root isa Node
+        # @test t_int.root isa Node
+        @test t_mixfs.root isa Node
         test_tree_consistency(tree=t_float, run_tests=t_float.root !== nothing)
-        # test_tree_consistency(tree=t_string, run_tests=t_string.root !== nothing)
+        test_tree_consistency(tree=t_string, run_tests=t_string.root !== nothing)
         # test_tree_consistency(tree=t_int, run_tests=t_int.root !== nothing)
+        test_tree_consistency(tree=t_mixfs, run_tests=t_mixfs.root !== nothing)
         @test calc_depth(t_float) == 2
-        # @test calc_depth(t_string) == 2
+        @test calc_depth(t_string) == 2
         # @test calc_depth(t_int) == 2 # TODO: this probably isn't 2 as we have 6 data points
+        @test calc_depth(t_mixfs) == 3 # TODO: optimal solution would be depth 2, but gini_impurity evaluates in a way, where all splits are considered equally good. Thus we get a suboptimal solution # TODO: optimal solution would be depth 2, but gini_impurity evaluates in a way, where all splits are considered equally good. Thus we get a suboptimal solution.
 
         pred_float = predict(t_float, dataset_float)
-        # pred_string = predict(t_string, dataset_string)
+        pred_string = predict(t_string, dataset_string)
         # pred_int = predict(t_int, dataset_int)
+        pred_mixfs = predict(t_mixfs, dataset_mixfs)
 
         @test length(pred_float) == 3
-        # @test length(pred_string) == 3
+        @test length(pred_string) == 3
         # @test length(pred_int) == 6
+        @test length(pred_mixfs) == 4
         @test calc_accuracy(abc_labels, pred_float) == 1.0
-        # @test calc_accuracy(abc_labels, pred_string) == 1.0
+        @test calc_accuracy(abc_labels, pred_string) == 1.0
         # @test calc_accuracy(aabcbb_labels, pred_int) == 1.0
+        @test calc_accuracy(abcd_labels, pred_mixfs) == 1.0
 
         #TODO: test mixed type and int features
         #TODO: test invalid inputs, should throw errors


### PR DESCRIPTION
categorical splitting decision was returned, when data could not be split e.g. just one data point categorical classes were determined by considering classes not contained in the current nodes dataset extended dataset type to allow for mixes of numerical & categorical data